### PR TITLE
refactor(keyboard): remove Ctrl+Alt+N, passthrough controls capture

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+use tauri::Emitter;
 
 mod windows;
 mod tray;
@@ -17,9 +18,13 @@ fn main() {
             windows::setup(app)?;
             tray::setup(app)?;
             shortcuts::setup(app)?;
-            // Inicia captura global de teclado
             keyboard::start(app.handle().clone());
             Ok(())
+        })
+        .on_window_event(|window, event| {
+            if let tauri::WindowEvent::Destroyed = event {
+                let _ = window.emit("keyboard-capture-stop", ());
+            }
         })
         .run(tauri::generate_context!())
         .expect("error while running TypeFlow");

--- a/src-tauri/src/shortcuts.rs
+++ b/src-tauri/src/shortcuts.rs
@@ -8,7 +8,6 @@ pub fn setup(app: &mut App) -> tauri::Result<()> {
 
     app.global_shortcut().on_shortcuts(
         [
-            Shortcut::new(Some(Modifiers::CONTROL | Modifiers::ALT), Code::KeyN),
             Shortcut::new(Some(Modifiers::CONTROL | Modifiers::ALT), Code::KeyV),
             Shortcut::new(Some(Modifiers::CONTROL | Modifiers::ALT), Code::KeyS),
             Shortcut::new(Some(Modifiers::CONTROL | Modifiers::ALT), Code::KeyC),
@@ -16,7 +15,6 @@ pub fn setup(app: &mut App) -> tauri::Result<()> {
         move |_app, shortcut, event| {
             if event.state == ShortcutState::Pressed {
                 match shortcut.key {
-                    Code::KeyN => toggle_card(&handle),
                     Code::KeyV => toggle_window(&handle, "viewer"),
                     Code::KeyS => { let _ = handle.emit("toggle-sound", ()); }
                     Code::KeyC => { let _ = handle.emit("toggle-click-through", ()); }
@@ -27,18 +25,6 @@ pub fn setup(app: &mut App) -> tauri::Result<()> {
     ).map_err(|e| tauri::Error::Anyhow(anyhow::anyhow!(e)))?;
 
     Ok(())
-}
-
-fn toggle_card(app: &tauri::AppHandle) {
-    if let Some(win) = app.get_webview_window("card") {
-        if win.is_visible().unwrap_or(false) {
-            let _ = win.hide();
-            let _ = app.emit("keyboard-capture-stop", ());
-        } else {
-            let _ = win.show();
-            let _ = app.emit("keyboard-capture-start", ());
-        }
-    }
 }
 
 fn toggle_window(app: &tauri::AppHandle, label: &str) {

--- a/src/components/card/Card.tsx
+++ b/src/components/card/Card.tsx
@@ -88,14 +88,38 @@ export function Card({ onFinish, onOpenViewer }: CardProps) {
     passthroughRef.current = next;
     setPassthrough(next);
     await getCurrentWindow().setIgnoreCursorEvents(next).catch(() => {});
+
+    const { emit } = await import("@tauri-apps/api/event");
+  if (next) {
+    await emit("keyboard-capture-stop");
+  } else {
+    await emit("keyboard-capture-start");
+  }
+
   }, []);
 
+    const toggleSound = useCallback(() => {
+    const next = !soundOn;
+    setSoundOn(next);
+    setSoundEnabled(next);
+    sounds.toggle(next);
+  }, [soundOn]);
+
   useEffect(() => {
-    let unlisten: (() => void) | null = null;
-    listen("toggle-click-through", () => togglePassthrough())
-      .then((fn) => { unlisten = fn; });
-    return () => { unlisten?.(); };
-  }, [togglePassthrough]);
+  let unlistenClick: (() => void) | null = null;
+  let unlistenSound: (() => void) | null = null;
+
+  listen("toggle-click-through", () => togglePassthrough())
+    .then((fn) => { unlistenClick = fn; });
+
+  listen("toggle-sound", () => toggleSound())
+    .then((fn) => { unlistenSound = fn; });
+
+  return () => {
+    unlistenClick?.();
+    unlistenSound?.();
+  };
+}, [togglePassthrough, toggleSound]);
 
   // Reasserta WS_EX_NOACTIVATE a cada clique — impede barra de tarefas
   useEffect(() => {
@@ -106,12 +130,6 @@ export function Card({ onFinish, onOpenViewer }: CardProps) {
     return () => window.removeEventListener("mousedown", handler, true);
   }, []);
 
-  const toggleSound = useCallback(() => {
-    const next = !soundOn;
-    setSoundOn(next);
-    setSoundEnabled(next);
-    sounds.toggle(next);
-  }, [soundOn]);
 
   const handleOpenViewer = useCallback(async () => {
     const { WebviewWindow } = await import("@tauri-apps/api/webviewWindow");

--- a/src/components/onboarding/Onboarding.tsx
+++ b/src/components/onboarding/Onboarding.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from "react";
 
 const SHORTCUTS = [
-  { key: "Ctrl + Alt + N", desc: "show / hide" },
   { key: "Ctrl + Alt + S", desc: "sound on / off" },
   { key: "Ctrl + Alt + V", desc: "view sessions" },
   { key: "Ctrl + Alt + C", desc: "click-through" },


### PR DESCRIPTION
- Remove Ctrl+Alt+N shortcut and toggle_card() from shortcuts.rs
- Emit keyboard-capture-start/stop on passthrough toggle
- Add toggle-sound listener in Card.tsx
- Disable keyboard capture on app close
- Remove Ctrl+Alt+N from Onboarding shortcuts list

Closes #2